### PR TITLE
Fix housing link to main page on evidence page

### DIFF
--- a/evidence/mechanics/gameplay-mechanics/housing.md
+++ b/evidence/mechanics/gameplay-mechanics/housing.md
@@ -2,7 +2,7 @@
 
 **Main Page:**
 
-{% page-ref page="housing.md" %}
+{% page-ref page="../../../mechanics/gameplay-mechanics/housing.md" %}
 
 ## Realm Currency Exchange Rate Analysis
 


### PR DESCRIPTION
At least I think this'll fix it.