### PR TITLE
Arrow self applied aura

### DIFF
--- a/evidence/mechanics/gameplay-mechanics/weapon-infusion.md
+++ b/evidence/mechanics/gameplay-mechanics/weapon-infusion.md
@@ -19,3 +19,21 @@ interacting with each other in specific ways that yield the appearance of a hier
 weapon once on double casting E and Diluc infuses his weapon every 0.5 seconds if it isn't imbued with Pyro. 
 The duration of these gauges differs between characters. Reactions on weapons follow the known reaction modifier rules 
 from other types of elemental application, and similar to Self-auras, can oscillate directly between elements without shifting to physical.
+  
+# Arrow Infusion  
+
+## Arrows are self applied aura entities  
+
+**By:** OAKUM\#0832  
+**Added:** 07/08/2021  
+[Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/860818239135547413/862658895611953162/transcript-arrows-are-self-applied-aura-entities.html)  
+
+**Finding:** Arrows are self-applied aura entities.  
+
+**Evidence:**  
+Venti’s arrows are swirled in the rain and Amber’s arrows are vaporized in the rain, showing that arrows are self-applied aura entities. 
+[Venti swirling twice in the rain](https://youtu.be/5hX2UeGsLXc)  
+[Amber vaporizing in the rain](https://youtu.be/qXwODL_xtuk)  
+[Rain swirl damage](https://youtu.be/yT7cYnd8wHo)  
+
+**Conclusion:** Arrows are entities that are infused with the same aura they apply.  

--- a/mechanics/gameplay-mechanics/weapon-infusion.md
+++ b/mechanics/gameplay-mechanics/weapon-infusion.md
@@ -20,6 +20,22 @@ Infusions apply a 1WU (Weapon gauge Unit) every refresh timing if overrideable\[
 | Noelle | Elemental Burst | Geo | Self | No | N/A |
 | Xiao | Elemental Burst | Anemo | Self | No | N/A |
 
+# Arrow Infusion  
+
+Arrows are continuously self infused with the same elemental gauge of the attack.
+
+## List of Arrow Infusions by element  
+
+| Element | Infused Arrow |
+| :--- | :--- |
+| Cryo | No infused element |
+| Pyro | Yes |
+| Hydro | Yes |
+| Electro | Yes |
+| Anemo | Yes |
+| Geo | - |
+| Dendro | - |
+
 ## Evidence Vault
 
 {% page-ref page="../../evidence/mechanics/gameplay-mechanics/weapon-infusion.md" %}


### PR DESCRIPTION
Adding Arrow infusion to weapon gauges, will most likely need to be revisited once yoimiya comes because non charged infused arrows could mess things up.