### PR TITLE
Razor energy fiasco

### DIFF
--- a/characters/anemo/xiao.md
+++ b/characters/anemo/xiao.md
@@ -85,7 +85,9 @@ Xiao dons the Yaksha Mask that set gods and demons trembling a millennia ago.
 * Increases his attack AoE and attack DMG.
 * Converts attack DMG into Anemo DMG, which cannot be overridden by any other elemental infusion. 
 * Xiao will continuously lose HP during this state. 
-* Xiao's attacks will be infused with 1GU Anemo.
+* Xiao's attacks will be infused with 1GU Anemo.  
+* While the effects of Elemental Burst: Bane of All Evil are active, the energy particle generation of Elemental Skill: Lemniscatic Wind Cycling
+ is disabled.  
 
 | Effect | Talent 6% |
 | :--- | :--- |

--- a/characters/electro/razor.md
+++ b/characters/electro/razor.md
@@ -84,7 +84,8 @@ Razor summons **The Wolf Within** which does Aoe Electro DMG and gains a echo at
 * Any active sigils will be absorbed by Razor granting him 5 energy for each sigil.
 * Increases attack speed by a % decided by talent level.
 * Razor also gains 80% Electro RES bonus, immunity against Electro-Charged, and resistance to interruption.
-* Razor’s hold E does not cause a minor self-knockback unlike outside of Lighning Fang.
+* Razor’s hold E does not cause a minor self-knockback unlike outside of Lighning Fang.  
+* While the effects of Elemental Burst: Ligthning Fang are active, the energy particle generation of Elemental Skill: Claw and Thunder is disabled.
 
 | Effect | Talent 6% / Data |
 | :--- | :--- |
@@ -96,9 +97,7 @@ Razor summons **The Wolf Within** which does Aoe Electro DMG and gains a echo at
 | Energy Cost | 80 |
 | Cast GU | 2B |
 | Echo U | 1A |
-| Frames | 62 |  
-
-While the effects of Elemental Burst: Ligthning Fang are active, the energy particle generation of Elemental Skill: Claw and Thunder is disabled.  
+| Frames | 62 |
 {% endtab %}
 {% endtabs %}
 

--- a/characters/electro/razor.md
+++ b/characters/electro/razor.md
@@ -96,7 +96,9 @@ Razor summons **The Wolf Within** which does Aoe Electro DMG and gains a echo at
 | Energy Cost | 80 |
 | Cast GU | 2B |
 | Echo U | 1A |
-| Frames | 62 |
+| Frames | 62 |  
+
+While the effects of Elemental Burst: Ligthning Fang are active, the energy particle generation of Elemental Skill: Claw and Thunder is disabled.  
 {% endtab %}
 {% endtabs %}
 


### PR DESCRIPTION
Clarifying that skill energy generation is disabled for razor&xiao on their main pages after a small fiasco in questionsplshalp yesterday.