### PR TITLE
Broken links fix

### DIFF
--- a/combat-mechanics/enemy-mechanics/enemy-interactions.md
+++ b/combat-mechanics/enemy-mechanics/enemy-interactions.md
@@ -57,7 +57,7 @@ The bubble from the Hydro Abyss Mages and their hydro bubble spawning mechanic c
 * Corrosion stacks are independent of each other, last for 10 seconds, and deal 10 total ticks of damage scaling linearly with each character's max HP.
 * Corrosion stacks applied by a Rifthound or Rifthound Whelp deal 0.5% max HP damage per tick.
 
-### Evidence Vault
+## Evidence Vault
 
 {% page-ref page="../../evidence/combat-mechanics/enemy-mechanics/enemy-interactions.md" %}
 

--- a/combat-mechanics/enemy-mechanics/enemy-shields-armor.md
+++ b/combat-mechanics/enemy-mechanics/enemy-shields-armor.md
@@ -10,7 +10,7 @@ description: >-
 
 Currently, there are two main types of shields that players should be aware of, **Elemental Shields** and **Elemental Armor**. We'll talk about what the differences are between these two shield types, as well as how to eliminate them. **An understanding of Gauge units and ICD is required.**
 
-{% page-ref page="../combat/elemental-reactions/" %}
+{% page-ref page="../elemental-effects/elemental-gauge-theory.md" %}
 
 ## Elemental Shields
 

--- a/combat-mechanics/spiral-domains/ley-line-disorders.md
+++ b/combat-mechanics/spiral-domains/ley-line-disorders.md
@@ -46,5 +46,5 @@ Other auras applied to your characters beforehand are removed entirely and do no
 
 ## Evidence Vault
 
-{% page-ref page="../../evidence/mechanics/combat/ley-line-disorders.md" %}
+{% page-ref page="../../evidence/combat-mechanics/spiral-domains/ley-line-disorders.md" %}
 

--- a/combat-mechanics/tech/plunge-tech.md
+++ b/combat-mechanics/tech/plunge-tech.md
@@ -53,4 +53,4 @@ It is possible to jump in the window that occurs before a character switches. De
 
 ## Evidence Vault:  
 
-{% page-ref page="../../../evidence/mechanics/combat/tech/plunge.md" %}  
+{% page-ref page="../../evidence/combat-mechanics/tech/plunge.md" %}  

--- a/equipment/artifacts.md
+++ b/equipment/artifacts.md
@@ -438,5 +438,5 @@
 
 **Evidence Vault**:
 
-{% page-ref page="../../evidence/mechanics/equipment/artifacts.md" %}
+{% page-ref page="../evidence/equipment/artifacts.md" %}
 

--- a/equipment/gadgets/parametric-transformer.md
+++ b/equipment/gadgets/parametric-transformer.md
@@ -21,4 +21,4 @@ You could check the evidence vault regarding Parametric Transformer for more det
 
 ## Evidence Vault
 
-{% page-ref page="../../../evidence/mechanics/equipment/gadgets/parametric-transformer.md" %}
+{% page-ref page="../../evidence/equipment/gadgets/parametric-transformer.md" %}

--- a/equipment/weapons/README.md
+++ b/equipment/weapons/README.md
@@ -18,5 +18,5 @@ Weapons can be refined by combining a weapon with one of the same type. This inc
 
 ## Evidence Vault
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/equipment/weapons/bows.md
+++ b/equipment/weapons/bows.md
@@ -773,5 +773,5 @@ There is a cap range for an arrow - damage just falls off after a certain range.
 
 **Evidence Vault:**
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/equipment/weapons/catalysts.md
+++ b/equipment/weapons/catalysts.md
@@ -692,5 +692,5 @@
 
 **Evidence Vault**:
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/equipment/weapons/claymores.md
+++ b/equipment/weapons/claymores.md
@@ -732,5 +732,5 @@ Attack Speed buffs do not dynamically affect Claymore Charged Attacks. Meaning, 
 
 **Evidence Vault:**
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/equipment/weapons/polearms.md
+++ b/equipment/weapons/polearms.md
@@ -621,5 +621,5 @@
 
 **Evidence Vault:**
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/equipment/weapons/swords.md
+++ b/equipment/weapons/swords.md
@@ -698,5 +698,5 @@
 
 **Evidence Vault:**
 
-{% page-ref page="../../../evidence/mechanics/equipment/weapons.md" %}
+{% page-ref page="../../evidence/equipment/weapons.md" %}
 

--- a/evidence/combat-mechanics/elemental-effects/elemental-gauge-theory.md
+++ b/evidence/combat-mechanics/elemental-effects/elemental-gauge-theory.md
@@ -490,7 +490,7 @@ Reviewed/Edited by: IonFox, Doug
 **By:** Aluminum#5462  
 [Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/851683689174925352/861402567899873320/transcript-tax-evasion.html)
 
-**Finding:** Contrary to what is stated in the evidence linked on the [Gauge Unit Theory](../../evidence/combat-mechanics/elemental-effects/elemental-gauge-theory.md#gauge-unit-theory-testing-and-evidence), taxation does not cause you to lose 20% of the gauge in the first 5% of the duration (hereinafter Hypothesis 1), but is applied instantly (hereinafter Hypothesis 2). Both hypothesis use the same total aura duration when no reactions occur.
+**Finding:** Contrary to what is stated in the evidence linked on the [Gauge Unit Theory](../../../evidence/combat-mechanics/elemental-effects/elemental-gauge-theory.md#gauge-unit-theory-testing-and-evidence), taxation does not cause you to lose 20% of the gauge in the first 5% of the duration (hereinafter Hypothesis 1), but is applied instantly (hereinafter Hypothesis 2). Both hypothesis use the same total aura duration when no reactions occur.
 
 **Evidence:** Duration testing was done on a 4A aura with 3U subtracted: [https://youtu.be/0hHF4GHo7uw](https://www.youtube.com/watch?v=0hHF4GHo7uw)
 

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-attributes.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-attributes.md
@@ -4,6 +4,10 @@ search: false
 
 # Enemy Attributes
 
+**Main Page:**
+
+{% page-ref page="../../../combat-mechanics/enemy-mechanics/enemy-attributes.md" %}
+
 ## In-Depth Look at Monster Skill Effects in Domains/Abyss
 
 **By:** Steno\#6940  

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-attributes.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-attributes.md
@@ -4,8 +4,6 @@ search: false
 
 # Enemy Attributes
 
-{% page-ref page="../../evidence/combat-mechanics/enemy-mechanics/enemy-attributes.md" %}
-
 ## In-Depth Look at Monster Skill Effects in Domains/Abyss
 
 **By:** Steno\#6940  

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md
@@ -4,6 +4,10 @@ search: false
 
 # Enemy Elemental Gauge
 
+**Main Page:**
+
+{% page-ref page="../../../combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md" %}
+
 ## Elemental Aura Application and Gauge Values of Enemies
 
 **By:** BowlSoldier\#3528  

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md
@@ -4,8 +4,6 @@ search: false
 
 # Enemy Elemental Gauge
 
-{% page-ref page="../../evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge.md" %}
-
 ## Elemental Aura Application and Gauge Values of Enemies
 
 **By:** BowlSoldier\#3528  

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-shields.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-shields.md
@@ -4,7 +4,7 @@ search: false
 
 # Enemy Shields and Armor
 
-{% page-ref page="../../evidence/combat-mechanics/enemy-mechanics/enemy-shields.md" %}
+{% page-ref page="../../../evidence/combat-mechanics/enemy-mechanics/enemy-shields.md" %}
 
 ## Reaction Efficiency at Breaking Elemental Shields \(Translation\)
 

--- a/evidence/combat-mechanics/frames.md
+++ b/evidence/combat-mechanics/frames.md
@@ -4,7 +4,9 @@ search: false
 
 # Frames
 
-{% page-ref page="../../evidence/combat-mechanics/frames.md" %}
+**Main Page:**  
+
+{% page-ref page="../../combat-mechanics/frames.md" %}  
 
 ## Hitlag Extension
 

--- a/evidence/combat-mechanics/poise.md
+++ b/evidence/combat-mechanics/poise.md
@@ -4,7 +4,9 @@ search: false
 
 # Poise
 
-{% page-ref page="../../evidence/combat-mechanics/poise.md" %}
+**Main Page:**  
+
+{% page-ref page="../../combat-mechanics/poise.md" %}  
 
 ## A Deep Dive into Genshin's Stagger Mechanics
 

--- a/evidence/combat-mechanics/snapshot-and-dynamic.md
+++ b/evidence/combat-mechanics/snapshot-and-dynamic.md
@@ -4,7 +4,9 @@ search: false
 
 # Snapshot and Dynamic
 
-{% page-ref page="../../evidence/combat-mechanics/snapshot-and-dynamic.md" %}
+**Main Page:**  
+
+{% page-ref page="../../combat-mechanics/snapshot-and-dynamic.md" %}  
 
 ## Summons are Not Dynamic and Snapshot on Cast
 

--- a/evidence/combat-mechanics/tech/arcc.md
+++ b/evidence/combat-mechanics/tech/arcc.md
@@ -4,6 +4,10 @@ search: false
 
 # ARCC
 
+**Main Page:**  
+
+{% page-ref page="../../../combat-mechanics/tech/arcc.md" %}
+
 ## How to ARCC
 
 **By:** BowTae#0141  

--- a/evidence/combat-mechanics/tech/collision-cancel.md
+++ b/evidence/combat-mechanics/tech/collision-cancel.md
@@ -4,6 +4,8 @@ search: false
 
 # Collision Cancel
 
+{% page-ref page="../../../combat-mechanics/tech/collision-cancel.md" %}
+
 **By:** BowTae#0141  
 **Added:** 10/09/2021  
 [Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/891494658901938176/894254618190700575/transcript-collision-jump.html)

--- a/evidence/combat-mechanics/tech/glide-cancel.md
+++ b/evidence/combat-mechanics/tech/glide-cancel.md
@@ -4,7 +4,11 @@ search: false
 
 # Glide Cancel
 
-## Wave Dashing
+**Main Page:**  
+
+{% page-ref page="../../../combat-mechanics/tech/glide-cancel.md" %}
+
+## Wavedashing
 
 **By:** BowTae#0141  
 **Added:** 09/14/2021  
@@ -14,6 +18,7 @@ search: false
 While in a wind current (such as Venti hold skill), you can jump, glide, and land instantly.  
 This is done by jumping, then pressing jump again exactly 4 frames later at 60 fps, or 2 frames later at 30 fps (not sure but I tried counting how many frames the jump took).  
 Has worked with every character I've tried so far, but there may be examples where this doesn't work.
+Can be known as glide cancel, wave dash, or wavedash.
 
 **Evidence:**  
 I found this technique through this video: [Bilibili Video](https://www.bilibili.com/video/BV1Cb4y1d7Kr?from=search&seid=9267604745435991278)
@@ -34,7 +39,7 @@ Amber examples as an amber main: [Imgur](https://imgur.com/6XJeJzU)
 **Significance:**  
 Could be used in teams with Venti to do extremely fast cancels without using stamina. Possibly consistent at 30 fps, but usability at 60fps is very questionable.
 
-## Geo construct Wave Dashing
+## Geo construct Wavedashing
 
 **By:** BowTae#0141  
 **Added:** 10/09/2021  

--- a/evidence/combat-mechanics/tech/plunge.md
+++ b/evidence/combat-mechanics/tech/plunge.md
@@ -4,6 +4,10 @@ search: false
 
 # Plunge tech
 
+**Main Page:**  
+
+{% page-ref page="../../../combat-mechanics/tech/plunge-tech.md" %}
+
 ## Dash-Jump-Plunge  
 
 **By:** Hatsuharufag#4291  

--- a/evidence/combat-mechanics/tech/zoom-cancel.md
+++ b/evidence/combat-mechanics/tech/zoom-cancel.md
@@ -4,6 +4,8 @@ search: false
 
 # Zoom Cancel
 
+{% page-ref page="../../../combat-mechanics/tech/zoom-cancel.md" %}
+
 **By:** randomspades \#0956  
 **Added:** 04/18/2021  
 [Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/815411615322341406/833576716701138984/transcript-elemental-burst-zoom-cancel.html)


### PR DESCRIPTION
please squash commits OMEGALUL
sorry, still too lazy to install anything when i realized I also had to download git to use visual studio pepela

the links on the weapons page to each weapon type looked ok, idk why it's still broken, this happened before too and idr what the fix was...

list of fixes:
vault link broken
-https://library.keqingmains.com/equipment/artifacts
-https://library.keqingmains.com/equipment/gadgets/parametric-transformer
-https://library.keqingmains.com/combat-mechanics/spiral-domains/ley-line-disorders
-https://library.keqingmains.com/combat-mechanics/spiral-domains/tech/plunge
-https://library.keqingmains.com/equipment/weapons
  -vault links for each weapon type also broken

link to main page broken
-https://library.keqingmains.com/evidence/combat-mechanics/enemy-mechanics/enemy-attributes
-https://library.keqingmains.com/evidence/combat-mechanics/enemy-mechanics/enemy-elemental-gauge
-https://library.keqingmains.com/evidence/combat-mechanics/enemy-mechanics/enemy-shields

link to main page links to vault page instead
-https://library.keqingmains.com/evidence/combat-mechanics/frames
-https://library.keqingmains.com/evidence/combat-mechanics/snapshot-and-dynamic
-https://library.keqingmains.com/evidence/combat-mechanics/poise

missing link to main page
-https://library.keqingmains.com/evidence/combat-mechanics/tech/arcc
-https://library.keqingmains.com/evidence/combat-mechanics/tech/collision-cancel
-https://library.keqingmains.com/evidence/combat-mechanics/tech/glide-cancel
-https://library.keqingmains.com/evidence/combat-mechanics/tech/plunge
-https://library.keqingmains.com/evidence/combat-mechanics/tech/zoom-cancel

other:
link to Elemental Reactions page is broken
-https://library.keqingmains.com/combat-mechanics/enemy-mechanics/enemy-shields-armor

Evidence Vault is indented on sidebar under "Corrosion Damage"
-https://library.keqingmains.com/combat-mechanics/enemy-mechanics/enemy-interactions