### PR TITLE
De-Aggro Distances

### DIFF
--- a/combat-mechanics/enemy-mechanics/enemy-interactions.md
+++ b/combat-mechanics/enemy-mechanics/enemy-interactions.md
@@ -71,6 +71,9 @@ The bubble from the Hydro Abyss Mages and their hydro bubble spawning mechanic c
 * Corrosion stacks are independent of each other, last for 10 seconds, and deal 10 total ticks of damage scaling linearly with each character's max HP.
 * Corrosion stacks applied by a Rifthound or Rifthound Whelp deal 0.5% max HP damage per tick.
 
+## De-Aggro Distances
+* Different types of enemies in the Overworld de-aggro at different ranges from their spawn, not at specific distances. These ranges take all 3 axes of the coordinate system into consideration.
+
 ## Evidence Vault
 
 {% page-ref page="../../evidence/combat-mechanics/enemy-mechanics/enemy-interactions.md" %}

--- a/evidence/combat-mechanics/enemy-mechanics/enemy-interactions.md
+++ b/evidence/combat-mechanics/enemy-mechanics/enemy-interactions.md
@@ -116,6 +116,28 @@ Characters’ marks \(Riptide, Talisman, Blood Blossom, etc.\) show that some en
 
 4. Geovishap Hatchlings are confirmed to be enemies from hell or purgatory or something. 
 
+### De-Aggro Distances  
+**By:** ep1k\#3678  
+**Added:** 01/27/2022  
+[Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/927244617441751060/936434058165121114/transcript-de-aggro-distances-vary-among-enemies.html)  
+
+**Theory:**  
+The de-aggro distance for Overworld enemies differs between them and is not a specific number, but rather a range from their spawn.  
+
+**Evidence:**  
+The distances are calculated using all 3 axis of the Genshin coordinate system from [this Vault Entry](https://library.keqingmains.com/evidence/general-mechanics/overworld#coordinates).  
+Testing method: [Video](https://youtu.be/fkoYcMKGYNg)  
+1. Use the Adventure Handbook to identify enemy spawn.  
+2. Get coordinates of the spawn location.  
+3. Take note of the location at which the enemy de-aggros (involves stopping to attack and going back to spawn).  
+4. Get coordinates of the current location.  
+
+Distances: [Images](https://imgur.com/a/I2EZ2Lw)  
+Summary: [Google Sheet](https://docs.google.com/spreadsheets/d/1s_A_RhVCkLn07XMWDMNMylLiJqhDERxAETmksI7B2Jg/edit#gid=1378246326)  
+
+**Significance:**  
+Insight into the behavior and mechanics of enemies in the Overworld.  
+
 ## General Boss Interactions
 
 ### Freeze Interaction on Boss Enemies

--- a/evidence/general-mechanics/miscellaneous-entries.md
+++ b/evidence/general-mechanics/miscellaneous-entries.md
@@ -347,7 +347,7 @@ To do this, you have to take a picture at the moment where you get hit/leap off 
 Knockback cancel/Fluff/investigating the influence pausing the game has on certain actions.
 
 ## Traveler Has Hidden Friendship Meter
-**By:** mmjacobs#9588  
+**By:** mmjacobs\#9588  
 **Added:** 1/23/2022  
 [Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/931045505801256971/934607873152012388/transcript-traveler-has-hidden-friendship-meter.html)
 
@@ -361,3 +361,21 @@ When Traveler is compared (i.e. sorted) with other characters with 0 Friendship,
 **Conclusion:**  
 Traveler does not accumulate friendship points, but does sort higher than other characters with zero friendship.
 
+## Portable Waypoint Bug  
+**By:** Sherbs\#2029  
+**Added:** 01/27/2022  
+[Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/934702460117856309/936406179373002782/transcript-portable-waypoint-interactions.html)  
+
+**Bug:**  
+When teleporting from a location with permanent weather or other effects on the map (such as lightning) to a Portable Waypoing in certain areas above or below the water (portions of the map that were added in 2.0 or zones that would get Paimon to yell at you if you went to far prior to 2.0), the game will transfer said effects to where the Portable Waypoint is located. These effects include permanent weather, lightning, wisps, and more. Prior to Patch 2.4b this would also replace the icon on the loading screen with the starting location instead of where the Portable Waypoint is placed. 
+
+**Evidence:**  
+Tutorial: [YouTube](https://youtu.be/cS2s1rRVb0A)  
+Photos:  
+* Teleporting from the Pyro Regisvine to The Crux: [Photo](https://imgur.com/w4WEcdR)  
+* Teleporting from Seirai Island facing The Crux: [Photo](https://imgur.com/VfXS4y2)  
+* Teleporting from Yashiori Island to the middle of the ocean: [Photo](https://imgur.com/RPm1jiL)  
+* Teleporting from Chinju Forest to The Crux: [Photo](https://imgur.com/k0WqHQW)  
+
+**Significance:**  
+For travelers who would like to have specific lighting on The Crux for photo contests.

--- a/general-mechanics/miscellaneous-entries.md
+++ b/general-mechanics/miscellaneous-entries.md
@@ -54,6 +54,9 @@ This applies to their respective triggers too.
     * Good Fortune = 3/16 = 18.75%
     * Great Fortune = 4/16 = 25%
 
+## Portable Waypoint Bug  
+* When placing the Portable Waypoint in certain places such as The Crux and teleporting from a location with an abnormal weather effect, it will be transferred to where the Portable Waypoint is.  
+
 ## Evidence Vault
 
 {% page-ref page="../evidence/general-mechanics/miscellaneous-entries.md" %}


### PR DESCRIPTION
idk why the 2 commits from the waypoint ticket are appearing here, also according to dictionaries the plural of "axis"  is "axes" and i found that out after committing the evidence, so the typo in "The distances are calculated using all 3 axis of the Genshin coordinate system from [this Vault Entry]" needs to be fixed