### PR TITLE
childe-e-cooldown-is-6-seconds-when-immediately-swapping

### DIFF
--- a/characters/hydro/tartaglia.md
+++ b/characters/hydro/tartaglia.md
@@ -92,6 +92,7 @@ Unleashes a set of weaponry made of pure water, dealing Hydro DMG to surrounding
 | Max Duration | 30s |
 | Preemptive CD | 6s ~ 36s |
 | Max CD | 45s |
+* Preemptive CD scales discretely, floored to an integer before cooldown reduction calculations.
 
 In this Stance, Tartaglia's Normal and Charged Attacks are converted to Hydro DMG that cannot be overridden by any other elemental infusion and change as follows:
 

--- a/evidence/characters/hydro/tartaglia.md
+++ b/evidence/characters/hydro/tartaglia.md
@@ -133,20 +133,7 @@ Childe's Skill cooldown duration appears discrete. If Childe is swapped off with
 
 **Evidence:**  
 6s cooldown on fast swap - [YouTube](https://youtu.be/x7z6cIrNfjM)  
-7s cooldown after 1.3s and 1.5s - [Youtube](https://youtu.be/-_YDfE3XYB8) and [YouTube](https://youtu.be/YaCT5owns_w)  
-Observed cooldowns:
-|Melee Time (s)|Cooldown (s)|Cooldown C1 (s)|
-|:---:|:---:|:---:|
-|0 ~ 1|6|4.8|
-|1 ~ 2|7|5.6|
-|2 ~ 4|8|6.4|
-|4 ~ 5|9|7.2|
-|5 ~ 6|10|8|
-|6 ~ 7|11|8.8|
-|7 ~ 8|12|9.6|
-|8 ~ 9|14|11.2|
-|9 ~ 10|15|12|
-|10 ~ 11|16|12.8|
+7s cooldown after 1.3s and 1.5s - [Youtube](https://youtu.be/-_YDfE3XYB8) and [YouTube](https://youtu.be/YaCT5owns_w)
 
 **Significance:**  
 Understanding cooldowns can allow more acurate theorycrafting and rotation building.  

--- a/evidence/characters/hydro/tartaglia.md
+++ b/evidence/characters/hydro/tartaglia.md
@@ -122,6 +122,36 @@ Skill and Burst on the Same Frame \(I will call this \[EQ\]\):
 * \[ErQ\] can potentially improve 4pc Shime Childe usability. Let's you tax evade with Ranged Burst which also refunds Energy, puts you into melee stance, and doesn't rely on high ping.
 * \[EmQ\] activates C6 on second skill rotation, which can allow for new potential setups.  
 
+### Childe E Cooldown is 6 Seconds When Immediately Swapped
+
+**By:** yolitme0\#0579 and BowTae\#0141  
+**Added:** 05/23/2022  
+[Discussion](https://tickettool.xyz/direct?url=https://cdn.discordapp.com/attachments/945097851195777054/978312827905396806/transcript-childe-e-cooldown-is-6-seconds-when-immediately-swapping.html)  
+
+**Finding:**  
+Childe's Skill cooldown duration appears discrete. If Childe is swapped off within 1 second of Elemental Skill activation, you get a 6 second cooldown duration. Likewise, swapping after 1.3 and 1.5 seconds both have same 7s cooldown duration.
+
+**Evidence:**  
+6s cooldown on fast swap - [YouTube](https://youtu.be/x7z6cIrNfjM)  
+7s cooldown after 1.3s and 1.5s - [Youtube](https://youtu.be/-_YDfE3XYB8) and [YouTube](https://youtu.be/YaCT5owns_w)  
+Observed cooldowns:
+|Melee Time (s)|Cooldown (s)|Cooldown C1 (s)|
+|:---:|:---:|:---:|
+|0 ~ 1|6|4.8|
+|1 ~ 2|7|5.6|
+|2 ~ 4|8|6.4|
+|4 ~ 5|9|7.2|
+|5 ~ 6|10|8|
+|6 ~ 7|11|8.8|
+|7 ~ 8|12|9.6|
+|8 ~ 9|14|11.2|
+|9 ~ 10|15|12|
+|10 ~ 11|16|12.8|
+
+**Significance:**  
+Understanding cooldowns can allow more acurate theorycrafting and rotation building.  
+Swapping off of Childe as soon as possible will minimize his cooldown if you made a mistake.
+
 ## Riptide Mechanics
 
 ### **Riptide Burst \(Enemy Kill\) can be triggered by other units**


### PR DESCRIPTION
ticket: #childe-e-cooldown-is-6-seconds-when-immediately-swapping